### PR TITLE
use pow() approximation as fallback for contrast

### DIFF
--- a/sass/_contrast.scss
+++ b/sass/_contrast.scss
@@ -33,11 +33,6 @@ $wcag-contrast: (
   $color: color($color);
   $luminance: 0;
 
-  @if not function-exists('pow') {
-    @error 'Luminance and contrast calculations require a `pow()` function '
-    + 'like the one available from MathSass.';
-  }
-
   @if (type-of($color) != 'color') {
     @error '`#{$color}` is not a color.';
   }
@@ -48,7 +43,15 @@ $wcag-contrast: (
     @if ($value < 0.03928) {
       $value: $value / 12.92;
     } @else {
-      $value: pow((($value + 0.055) / 1.055), 2.4);
+      $base: ($value + 0.055) / 1.055;
+      @if function-exists('pow') {
+        $value: pow($base, 2.4);
+      } @else {
+        @error 'Luminance and contrast calculations require a `pow()` '
+        + 'function like the one available from MathSass. Falling back to '
+        + 'rough approximation';
+        $value: 0.56 * ($base * $base * $base) + 0.44 * ($base * $base);
+      }
     }
 
     @if ($component == 'red') {

--- a/sass/_contrast.scss
+++ b/sass/_contrast.scss
@@ -47,7 +47,7 @@ $wcag-contrast: (
       @if function-exists('pow') {
         $value: pow($base, 2.4);
       } @else {
-        @error 'Luminance and contrast calculations require a `pow()` '
+        @warn 'Luminance and contrast calculations require a `pow()` '
         + 'function like the one available from MathSass. Falling back to '
         + 'rough approximation';
         $value: 0.56 * ($base * $base * $base) + 0.44 * ($base * $base);


### PR DESCRIPTION
This replaces #5.

Sorry for the magic numbers. I tried for a whole day to come up with the mathematically optimal values, but then I just gave up and started experimenting.

The issue with #5 is that the contrast forumlar amplifies any errors we produce in this step. The new approximation will produce higher maximum errors for luminance, but better general results for contrast.