### PR TITLE
Fix warnings with node-sass 4.8.3

### DIFF
--- a/sass/_contrast.scss
+++ b/sass/_contrast.scss
@@ -211,6 +211,9 @@ $WCAG-CONTRAST: ( // sass-lint:disable-line variable-name-format
   }
 
   @each $component in 'red' 'green' 'blue' {
+    @if (function-exists('get-function')) {
+      $component: get-function($component);
+    }
     $value: call($component, $color) / 255;
 
     @if ($value < 0.03928) {

--- a/sass/_utils.scss
+++ b/sass/_utils.scss
@@ -71,16 +71,11 @@
   $function
 ) {
   $type: type-of($function);
-  $local: ('tint', 'shade');
 
   @if ($type == 'function') {
     @return $function;
   } @else if ($type == 'string') and function-exists('get-function') {
-    @if index($local, $function) {
-      @return get-function($function);
-    }
-
-    @error '[#{$type}] `#{$function}` must be a first-class function';
+    @return get-function($function);
   }
 
   @return $function;


### PR DESCRIPTION
Fixes warnings/errors, e.g.:

```
DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal
in Sass 4.0. Use call(get-function("red")) instead.
```

```
[string] `rgba` must be a first-class function
```